### PR TITLE
Pass validationOptions through to ValidateBy

### DIFF
--- a/src/IsULID.ts
+++ b/src/IsULID.ts
@@ -20,5 +20,5 @@ export function IsULID(
         validationOptions
       ),
     },
-  })
+  }, validationOptions)
 }


### PR DESCRIPTION
By passing `validationOptions` as the last argument of `ValidateBy`, it will respect options like
```typescript
@IsULID({ each: true }) // for validating arrays of ULIDs
```